### PR TITLE
fix: locking pnpm version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,12 +44,12 @@ node {
 }
 
 task buildFrontend(type: NpxTask) {
-    command = 'pnpm'
+    command = 'pnpm@7'
     args = ['build']
 }
 
 task pnpmInstall(type: NpxTask) {
-    command = "pnpm"
+    command = "pnpm@7"
     args = ["install"]
 }
 


### PR DESCRIPTION
锁定 pnpm 版本为 7，解决 ci 报错问题。

/kind bug

```release-note
None
```