### PR TITLE
Update UmamiTrackerProcessor.java

### DIFF
--- a/src/main/java/run/halo/umami/UmamiTrackerProcessor.java
+++ b/src/main/java/run/halo/umami/UmamiTrackerProcessor.java
@@ -32,7 +32,7 @@ public class UmamiTrackerProcessor implements TemplateHeadProcessor {
 
     private String trackerScript(String websiteId, String endpoint) {
         return """
-                <script async defer data-website-id="%s" src="%s/umami.js"></script>
+                <script async defer data-website-id="%s" src="%s"></script>
                 """.formatted(websiteId, endpoint);
     }
 


### PR DESCRIPTION
修复新版本umami版本路径问题
老版本路径为：https://analytics.winy.cc/umami.js
新版本路径为：https://analytics.winy.cc/script.js