### PR TITLE
feat: show plugin settings modal when share url is not config

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,7 @@
 {
+  "type": "module",
   "scripts": {
-    "dev": "vite build --watch",
+    "dev": "vite build --watch --mode=development",
     "build": "vite build",
     "preview": "vite preview --port 4173",
     "test:unit": "vitest --environment jsdom",

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -1,56 +1,18 @@
 import { fileURLToPath, URL } from "url";
 
-import { defineConfig } from "vite";
+import { HaloUIPluginBundlerKit } from "@halo-dev/ui-plugin-bundler-kit";
 import Vue from "@vitejs/plugin-vue";
 import Icons from "unplugin-icons/vite";
+import { defineConfig } from "vite";
 
-export default ({ mode }: { mode: string }) => {
-  const isProduction = mode === "production";
-  const outDir = isProduction
-    ? "../src/main/resources/console"
-    : "../build/resources/main/console";
-
-  return defineConfig({
-    plugins: [Vue(), Icons({ compiler: "vue3" })],
-    resolve: {
-      alias: {
-        "@": fileURLToPath(new URL("./src", import.meta.url)),
-      },
+export default defineConfig({
+  plugins: [Vue(), Icons({ compiler: "vue3" }), HaloUIPluginBundlerKit()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
-    define: {
-      "process.env": process.env,
-    },
-    build: {
-      outDir,
-      emptyOutDir: true,
-      lib: {
-        entry: "src/index.ts",
-        name: "PluginUmami",
-        formats: ["iife"],
-        fileName: () => "main.js",
-      },
-      rollupOptions: {
-        external: [
-          "vue",
-          "vue-router",
-          "@vueuse/core",
-          "@vueuse/components",
-          "@vueuse/router",
-          "@halo-dev/shared",
-          "@halo-dev/components",
-        ],
-        output: {
-          globals: {
-            vue: "Vue",
-            "vue-router": "VueRouter",
-            "@vueuse/core": "VueUse",
-            "@vueuse/components": "VueUse",
-            "@vueuse/router": "VueUse",
-            "@halo-dev/console-shared": "HaloConsoleShared",
-            "@halo-dev/components": "HaloComponents",
-          },
-        },
-      },
-    },
-  });
-};
+  },
+  define: {
+    "process.env": process.env,
+  },
+});

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   enabled: true
   version: 1.0.0
-  requires: ">=2.0.0"
+  requires: ">=2.17.0"
   author:
     name: Halo
     website: https://github.com/halo-dev


### PR DESCRIPTION
支持在进入 Umami 页面时检查是否配置 Umami 共享链接，如果没有配置，则弹出插件设置界面引导用户设置。

<img width="1669" alt="image" src="https://github.com/halo-sigs/plugin-umami/assets/21301288/4d4bbba8-7166-440a-8e24-2a5b7645ea48">

/kind feature

```release-note
支持在未设置共享链接时，自动打开插件设置界面。
```