### PR TITLE
chore: remove deprecated plugin wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,11 @@ plugins {
 }
 
 group 'run.halo.umami'
-sourceCompatibility = JavaVersion.VERSION_17
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
     maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }

--- a/src/main/java/run/halo/umami/UmamiPlugin.java
+++ b/src/main/java/run/halo/umami/UmamiPlugin.java
@@ -1,8 +1,9 @@
 package run.halo.umami;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
+
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 /**
  * @author guqing
@@ -11,8 +12,8 @@ import run.halo.app.plugin.BasePlugin;
 @Component
 public class UmamiPlugin extends BasePlugin {
 
-    public UmamiPlugin(PluginWrapper wrapper) {
-        super(wrapper);
+    public UmamiPlugin(PluginContext context) {
+        super(context);
     }
 
     @Override


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用，Halo 2.18.0 版本后将不在支持从 BasePlugin 中获取 PluginWrapper ，也不再支持依赖注入 PluginWrapper，使用 PluginContext 代替

see also https://github.com/halo-dev/halo/pull/6243 for more details

```release-note
None
```